### PR TITLE
Change admin controller name

### DIFF
--- a/app/controllers/admin_dashboard_controller.rb
+++ b/app/controllers/admin_dashboard_controller.rb
@@ -1,0 +1,4 @@
+class AdminDashboardController < ApplicationController
+  def index
+  end
+end

--- a/app/views/admin_dashboard/index.html.erb
+++ b/app/views/admin_dashboard/index.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <h1>Admin#index</h1>
+  <p>Find me in app/views/admin/index.html.erb</p>
+  <%= link_to 'Users', users_path %>
+  <%= link_to 'Companies', companies_path %>
+  <%= link_to 'Campaigns', campaigns_path %>
+</div>

--- a/test/controllers/admin_dashboard_controller_test.rb
+++ b/test/controllers/admin_dashboard_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class AdminDashboardControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_dashboard_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
The_ admin controller now is called admin_dashboard_controller this to
have a more descriptive name in the controller and avoid confusing it with
the admins controller, which manage admins users sessions